### PR TITLE
Enforces single trailing slash in base url

### DIFF
--- a/keystone_client/client.py
+++ b/keystone_client/client.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from functools import partial
 from typing import Literal, Union
 from warnings import warn
-
+import urllib.parse
 import jwt
 import requests
 
@@ -57,7 +57,7 @@ class KeystoneClient:
             url: The base URL for a running Keystone API server
         """
 
-        self._url = url.rstrip('/')
+        self._url = url
         self._api_version: str | None = None
         self._access_token: str | None = None
         self._access_expiration: datetime | None = None
@@ -153,7 +153,7 @@ class KeystoneClient:
 
         self._refresh_tokens(force=False, timeout=timeout)
 
-        url = f'{self.url}/{endpoint}'
+        url = urllib.parse.urljoin(self.url, endpoint)
         response = requests.request(method, url, **kwargs)
         response.raise_for_status()
         return response
@@ -162,7 +162,8 @@ class KeystoneClient:
     def url(self) -> str:
         """Return the server URL"""
 
-        return self._url
+        # Make sure the url includes a single trailing slash
+        return self._url.rstrip('/') + '/'
 
     def http_get(
         self,

--- a/tests/test_url_handling.py
+++ b/tests/test_url_handling.py
@@ -9,10 +9,12 @@ class TestUrl(TestCase):
     """Tests for the `url` property"""
 
     def test_trailing_slash_removed(self):
-        """Test trailing slashes are removed from URLs provided at init"""
+        """Test extra trailing slashes are removed from URLs provided at init"""
 
-        # Test for various numbers of trailing slashes
-        url = 'http://test.domain.com'
-        self.assertEqual(url, KeystoneClient(url).url)
-        self.assertEqual(url, KeystoneClient(url + '/').url)
-        self.assertEqual(url, KeystoneClient(url + '////').url)
+        base_url = 'https://test.domain.com'
+        expected_url = base_url + '/'
+
+        # Test for various numbers of trailing slashes provided at init
+        self.assertEqual(expected_url, KeystoneClient(base_url).url)
+        self.assertEqual(expected_url, KeystoneClient(base_url + '/').url)
+        self.assertEqual(expected_url, KeystoneClient(base_url + '////').url)


### PR DESCRIPTION
The API is designed to enforce trailing slashes. It makes sense for the client to behave consistently.