### PR TITLE
Adds tests for CRUD methods

### DIFF
--- a/tests/client/test_keystone_client.py
+++ b/tests/client/test_keystone_client.py
@@ -35,11 +35,12 @@ class APIVersion(TestCase):
 class Create(TestCase):
     """Test record creation via the `create_cluster` method"""
 
-    def setUp(self) -> None:
+    @classmethod
+    def setUpClass(cls) -> None:
         """Authenticate a new API client instance"""
 
-        self.client = KeystoneClient(API_HOST)
-        self.client.login(API_USER, API_PASSWORD)
+        cls.client = KeystoneClient(API_HOST)
+        cls.client.login(API_USER, API_PASSWORD)
 
     def tearDown(self) -> None:
         """Delete any test records"""
@@ -78,11 +79,16 @@ class Create(TestCase):
 class Retrieve(TestCase):
     """Test record retrieval via the `retrieve_cluster` method"""
 
-    def setUp(self) -> None:
-        """Set up a test client and create records for testing"""
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Authenticate a new API client instance"""
 
-        self.client = KeystoneClient(API_HOST)
-        self.client.login(API_USER, API_PASSWORD)
+        cls.client = KeystoneClient(API_HOST)
+        cls.client.login(API_USER, API_PASSWORD)
+
+    def setUp(self) -> None:
+        """Create records for testing"""
+
         self.test_cluster = self.client.create_cluster(
             name='Test-Cluster',
             description='Cluster created for retrieval testing purposes.'
@@ -141,11 +147,16 @@ class Retrieve(TestCase):
 class Update(TestCase):
     """Test record updates via the `update_cluster` method"""
 
-    def setUp(self) -> None:
-        """Set up a test client and create records for testing"""
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Authenticate a new API client instance"""
 
-        self.client = KeystoneClient(API_HOST)
-        self.client.login(API_USER, API_PASSWORD)
+        cls.client = KeystoneClient(API_HOST)
+        cls.client.login(API_USER, API_PASSWORD)
+
+    def setUp(self) -> None:
+        """Create records for testing"""
+
         self.test_cluster = self.client.create_cluster(
             name='Test-Cluster',
             description='Cluster created for update testing purposes.'
@@ -196,18 +207,23 @@ class Update(TestCase):
 class Delete(TestCase):
     """Test record deletion via the `delete_cluster` method"""
 
-    def setUp(self) -> None:
-        """Set up the test client and log in"""
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Authenticate a new API client instance"""
 
-        self.client = KeystoneClient(API_HOST)
-        self.client.login(API_USER, API_PASSWORD)
+        cls.client = KeystoneClient(API_HOST)
+        cls.client.login(API_USER, API_PASSWORD)
+
+    def setUp(self) -> None:
+        """Create records for testing"""
+
         self.test_cluster = self.client.create_cluster(
             name='Test-Cluster',
             description='Cluster created for delete testing purposes.'
         )
 
     def tearDown(self) -> None:
-        """Clean up by deleting existing test clusters"""
+        """Delete any test records"""
 
         for cluster in self.client.http_get(f'allocations/clusters/', params={'name': 'Test-Cluster'}).json():
             self.client.http_delete(f"allocations/clusters/{cluster['id']}").raise_for_status()

--- a/tests/client/test_keystone_client.py
+++ b/tests/client/test_keystone_client.py
@@ -76,3 +76,26 @@ class Create(TestCase):
         with self.assertRaises(HTTPError):
             self.client.create_cluster()
 
+
+class Retrieve(TestCase):
+    """Test record retrieval via the `retrieve_cluster` method"""
+
+    def test_retrieve_by_pk(self) -> None:
+        """Test the retrieval of a specific record via its primary key"""
+
+        self.fail()
+
+    def test_retrieve_by_filters(self) -> None:
+        """Test the filtering of returned records via search params"""
+
+        self.fail()
+
+    def test_retrieve_all(self) -> None:
+        """Test the retrieval of all records"""
+
+        self.fail()
+
+    def test_none_on_missing_record(self) -> None:
+        """Test `None` is returned when a record does not exist"""
+
+        self.fail()

--- a/tests/client/test_keystone_client.py
+++ b/tests/client/test_keystone_client.py
@@ -130,6 +130,13 @@ class Retrieve(TestCase):
         missing_cluster = self.client.retrieve_cluster(pk=999999)
         self.assertIsNone(missing_cluster)
 
+    def test_error_on_failure(self) -> None:
+        """Test an error is raised when record retrieval fails"""
+
+        # Use an unauthenticated client session on an endpoint requiring authentication
+        with self.assertRaises(HTTPError):
+            KeystoneClient(API_HOST).retrieve_cluster()
+
 
 class Update(TestCase):
     """Test record updates via the `update_cluster` method"""


### PR DESCRIPTION
Uses the cluster endpoint as a proxy for CRUD methods in general.

Closes #38 